### PR TITLE
Add tests & simplify logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+/cache
+/lib/**/*
+/out

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,6 @@
+[default]
+src = 'src'
+out = 'out'
+libs = ['lib']
+
+# See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/src/DelegationManagement.sol
+++ b/src/DelegationManagement.sol
@@ -182,7 +182,7 @@ contract delegationManagement {
      function retrieveActiveToDelegations(address _profileAddress, address _collectionAddress, uint256 _date, uint256 _useCase) external view returns (address[] memory ) {
         bytes32 hash;
         hash = keccak256(abi.encodePacked(_profileAddress, _collectionAddress, _useCase));
-        address[] memory allDelegations;
+        address[] memory allDelegations = new address[](delegateToHashes[hash].length);
         uint256 count;
         count=0;
         for (uint256 i=0; i<=delegateToHashes[hash].length-1; i++){

--- a/test/DelegationManagement.t.sol
+++ b/test/DelegationManagement.t.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "forge-std/Vm.sol";
+
+import {delegationManagement} from "../src/DelegationManagement.sol";
+
+contract ContractTest is Test {
+    delegationManagement delegation;
+
+    function setUp() public {
+        delegation = new delegationManagement();
+    }
+
+    function testRegisterAfterExpired() public {
+        address collection = 0xBEeFeEb84610509DFE31B420c8D062ab00153D24;
+        address delegationAddr = 0xc0ffeeB84610509DFE31B420c8d062AB00153D24;
+
+        uint256 usecase = 14;
+        uint256 ts = 1;
+
+        bytes32 toHash = keccak256(abi.encodePacked(address(this), collection, usecase));
+        uint256 toLength = delegation.toHashCounter(toHash);
+
+        assertEq(toLength, 0);
+
+        delegation.registerDelegationAddress(collection, delegationAddr, ts, usecase);
+
+        toLength = delegation.toHashCounter(toHash);
+        assertEq(toLength, 1);
+
+        vm.warp(10);
+
+        vm.expectRevert(); // current implementation fails here
+        delegation.registerDelegationAddress(collection, delegationAddr, 12, usecase);
+    }
+
+    function testRevokeSingle() public {
+        address collection = 0xBEeFeEb84610509DFE31B420c8D062ab00153D24;
+        address delegationAddr = 0xc0ffeeB84610509DFE31B420c8d062AB00153D24;
+
+        uint256 usecase = 14;
+        uint256 ts = 1;
+
+        bytes32 toHash = keccak256(abi.encodePacked(address(this), collection, usecase));
+        uint256 beforeLength = delegation.toHashCounter(toHash);
+
+        assertEq(beforeLength, 0);
+
+        delegation.registerDelegationAddress(collection, delegationAddr, ts, usecase);
+
+        uint256 afterLength = delegation.toHashCounter(toHash);
+        assertEq(afterLength, 1);
+        
+        delegation.revokeDelegationAddress(collection, delegationAddr, usecase);
+
+        uint256 afterDelLength = delegation.toHashCounter(toHash);
+        assertEq(afterDelLength, 0);
+    }
+
+    function testRevokeMultiple() public {
+        address collection = 0xBEeFeEb84610509DFE31B420c8D062ab00153D24;
+        address delegationAddr = 0xc0ffeeB84610509DFE31B420c8d062AB00153D24;
+
+        address collection2 = 0xbeEfEeb84610509DFE31B420c8D062Ab00153d23;
+
+        address delegationAddr2 = 0xC0FFEeb84610509dFe31B420c8d062aB00153D23;
+
+        uint256 usecase = 14;
+        uint256 ts = 1;
+
+        bytes32 toHash = keccak256(abi.encodePacked(address(this), collection, usecase));
+        bytes32 toHash2 = keccak256(abi.encodePacked(address(this), collection2, usecase));
+        uint256 toHashLength = delegation.toHashCounter(toHash);
+        uint256 toHashLength2 = delegation.toHashCounter(toHash2);
+
+        assertEq(toHashLength, 0);
+        assertEq(toHashLength2, 0);
+
+        delegation.registerDelegationAddress(collection, delegationAddr, ts, usecase);
+
+        toHashLength = delegation.toHashCounter(toHash);
+        toHashLength2 = delegation.toHashCounter(toHash2);
+        assertEq(toHashLength, 1);
+        assertEq(toHashLength2, 0);
+
+        delegation.registerDelegationAddress(collection2, delegationAddr2, ts, usecase);
+
+        toHashLength = delegation.toHashCounter(toHash);
+        toHashLength2 = delegation.toHashCounter(toHash2);
+        assertEq(toHashLength, 1);
+        assertEq(toHashLength2, 1);
+
+        delegation.revokeDelegationAddress(collection, delegationAddr, usecase);
+
+        toHashLength = delegation.toHashCounter(toHash);
+        toHashLength2 = delegation.toHashCounter(toHash2);
+        assertEq(toHashLength, 0);
+        assertEq(toHashLength2, 1);
+    }
+
+    function testRetrieveToDelegationAddresses() public {
+        address collection = 0xBEeFeEb84610509DFE31B420c8D062ab00153D24;
+        address delegationAddr = 0xc0ffeeB84610509DFE31B420c8d062AB00153D24;
+
+        uint256 usecase = 14;
+        uint256 ts = 1;
+
+        delegation.registerDelegationAddress(collection, delegationAddr, ts, usecase);
+
+        address[] memory result = delegation.retrieveToDelegationAddressesPerUsecaseForCollection(address(this), collection, usecase);
+
+        assertEq(result.length, 1);
+        assertEq(result[0], delegationAddr);
+    }
+
+    function testRetrieveFromDelegationAddresses() public {
+        address collection = 0xBEeFeEb84610509DFE31B420c8D062ab00153D24;
+        address delegationAddr = 0xc0ffeeB84610509DFE31B420c8d062AB00153D24;
+
+        uint256 usecase = 14;
+        uint256 ts = 1;
+
+        delegation.registerDelegationAddress(collection, delegationAddr, ts, usecase);
+
+        address[] memory result = delegation.retrieveFromDelegationAddressesPerUsecaseForCollection(delegationAddr, collection, usecase);
+
+        assertEq(result.length, 1);
+        assertEq(result[0], address(this));
+    }
+
+    function testRetieveActiveTo() public {
+        address collection = 0xBEeFeEb84610509DFE31B420c8D062ab00153D24;
+        address delegationAddr = 0xc0ffeeB84610509DFE31B420c8d062AB00153D24;
+
+        uint256 usecase = 14;
+        uint256 ts = 3;
+
+        delegation.registerDelegationAddress(collection, delegationAddr, ts, usecase);
+
+        address[] memory result = delegation.retrieveActiveToDelegations(address(this), collection, 1, usecase);
+
+        assertEq(result.length, 1);
+        assertEq(result[0], delegationAddr);
+
+        vm.warp(2);
+
+        address[] memory result2 = delegation.retrieveActiveToDelegations(address(this), collection, 5, usecase);
+
+        // this fails
+        assertEq(result2.length, 0);        
+    }
+}


### PR DESCRIPTION
I agree with the comments made in [1](https://github.com/6529-Collections/nftdelegation/pull/1) and as such haven't made any modifications to errors or syntax. 

Simplified the logic for the register / revoke functions, though upon further reflection these could be improved further (perhaps with different storage layouts). Knocked off around 45k gas from `register` and around 10k gas from `revoke`. 

I added some simple forge tests to cover the base use cases and found the following issues:

* The `require(registeredDelegation[globalHash] == false);` check in `registerDelegationAddress` means that it is impossible to add more than one `delegationAddresses` per hash (which makes the most of the mapping redundant). 
* Both `retrieveActiveFromDelegations` and `retrieveActiveToDelegations` create fixed size arrays matching all delegations. This means that it could return an array with address(0) elements. For example, if the `delegationAddresses[]` for a given hash has 3 entries, two of which are expired in slots 0 and 1 then with the current implementation would return `[0x000..., 0x000..., <delegation address>]` - for large array sizes this would require further processing to get the correct information. 
* Counter mappings weren't strictly necessary, could just use the `length` of the returning `delegationAddresses[]` for a given hash.


The code in this PR isn't perfect either (only had a little bit of time) but I think some more fundamental changes are required - I'm submitting it because it could be some help but no drama if it isn't. 