### PR TITLE
Pack the struct to save significant gas

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Use-Case  | Action
 12 | Gameplay
 13 | IP Licensing
 14 | Sub-delegation
-99 | Consolidation
+255 | Consolidation
 
 #### Why is delegation useful?
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Simply put, the proposed contract implementation deploys a "Delegation Managemen
 
 #### Purpose
 
-- It is often the case that wallet owners wish to assign delegation rights (in this context let's refer to assigners as "Delegators") to some other wallet address to act on their behalf. 
+- It is often the case that wallet owners wish to assign delegation rights (in this context let's refer to assigners as "Delegators") to some other wallet address to act on their behalf.
 - A Delegator can assign a delegation address for a specific use case on a specific NFT collection for a certain duration.
-- We note that the action of "delegation" does not assign any ownership (including its assets) on the Delegator's wallet. 
+- We note that the action of "delegation" does not assign any ownership (including its assets) on the Delegator's wallet.
 
 #### Use Cases
 
@@ -49,8 +49,8 @@ Use-Case  | Action
     3. verifying/proving token ownership e.g., apps that implement some token gated policy
     4. or any other activity that relates to the above use-cases
 &nbsp;
-- Overall, this contract proposal is useful for use-cases where dApps require a global, on-chain registry that maps the "delegation" relationship between wallet addresses. 
-	
+- Overall, this contract proposal is useful for use-cases where dApps require a global, on-chain registry that maps the "delegation" relationship between wallet addresses.
+
 #### Features
 
 - Current implementation enables the following functionality:

--- a/src/DelegationManagement.sol
+++ b/src/DelegationManagement.sol
@@ -49,7 +49,7 @@ contract delegationManagement {
     error NoGlobalHashOnRegisteredDelegation();
 
     // Constructor
-    constructor(uint8 _counter) public {
+    constructor(uint8 _counter) {
         useCaseCounter = _counter;
     }
 

--- a/src/DelegationManagement.sol
+++ b/src/DelegationManagement.sol
@@ -165,7 +165,7 @@ contract delegationManagement {
      * @notice Support function used to retrieve the hash given specific parameters
      *
      */
-    function retrieveHash(address _profileAddress, address _collectionAddress, uint256 _useCase) public view returns (bytes32) {
+    function retrieveHash(address _profileAddress, address _collectionAddress, uint256 _useCase) public pure returns (bytes32) {
         bytes32 hash;
         hash = keccak256(abi.encodePacked(_profileAddress,_collectionAddress,_useCase));
         return (hash);

--- a/src/DelegationManagement.sol
+++ b/src/DelegationManagement.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 
-/** 
+/**
  *
- *  @title: Delegation Management Contract   
+ *  @title: Delegation Management Contract
  *  @date: 21-Dec-2022 @ 10:30
- *  @version: 4.23 
+ *  @version: 4.23
  *  @notes: This is a experimental contract for delegation registry
  *  @author: skynet2030 (skyn3t2030)
  *
@@ -15,7 +15,7 @@ pragma solidity >=0.6.0 <=0.8.0;
 contract delegationManagement {
 
     // Variable declarations
-    uint256 useCaseCounter; 
+    uint256 useCaseCounter;
 
     // Mapping declarations
     mapping (bytes32 => bool) public registeredDelegation;
@@ -44,18 +44,18 @@ contract delegationManagement {
     event registerDelegation(address indexed from, address indexed collectionAddress, address indexed delegationAddress, uint256 useCase);
     event revokeDelegation(address indexed from, address indexed collectionAddress, address indexed delegationAddress, uint256 useCase);
     event updateDelegation(address indexed from, address indexed collectionAddress, address olddelegationAddress, address indexed newdelegationAddress, uint256 useCase);
-    
+
     // Constructor
     constructor() public {
         useCaseCounter = 15;
     }
-  
+
     /**
      * @notice Delegator assigns a delegation address for a specific use case on a specific NFT collection for a certain duration
-     * 
+     *
      */
     function registerDelegationAddress(address _collectionAddress, address _delegationAddress, uint256 _expiryDate, uint256 _useCase) public {
-        require((_useCase >0 && _useCase < useCaseCounter) || (_useCase == 99));
+        require((_useCase > 0 && _useCase < useCaseCounter) || (_useCase == 99));
         bytes32 toHash;
         bytes32 fromHash;
         bytes32 globalHash;
@@ -68,14 +68,13 @@ contract delegationManagement {
         delegateFromHashes[fromHash].push(newdelegationAddress);
 		delegationToCounterPerHash[toHash] = delegationToCounterPerHash[toHash] + 1;
         delegationFromCounterPerHash[fromHash] = delegationFromCounterPerHash[fromHash] + 1;
-        registeredDelegation[globalHash] =true;
+        registeredDelegation[globalHash] = true;
         emit registerDelegation(msg.sender, _collectionAddress, _delegationAddress, _useCase);
-
     }
 
     /**
-     * @notice Delegator revokes delegation rights from a delagation address given to a specific use case on a specific NFT collection
-     * 
+     * @notice Delegator revokes delegation rights from a delegation address given to a specific use case on a specific NFT collection
+     *
      */
     function revokeDelegationAddress(address _collectionAddress, address _delegationAddress, uint256 _useCase) public {
         bytes32 toHash;
@@ -86,65 +85,70 @@ contract delegationManagement {
         toHash = keccak256(abi.encodePacked(msg.sender, _collectionAddress, _useCase));
         fromHash = keccak256(abi.encodePacked(_delegationAddress, _collectionAddress, _useCase));
         // delete from toHashes mapping
-        count=0;
-        for (uint256 i=0; i<=delegationToCounterPerHash[toHash]-1; i++){
+        count = 0;
+        for (uint256 i = 0; i <= delegationToCounterPerHash[toHash] - 1; i++){
             if (globalHash == delegateToHashes[toHash][i].delegationGlobalHash) {
-                count=count+1;
+                count = count + 1;
             }
         }
+
         uint256[] memory delegationsPerUser = new uint256[](count);
-        uint256 count1=0;
-        for (uint256 i=0; i<=delegationToCounterPerHash[toHash]-1; i++){
+        uint256 count1 = 0;
+        for (uint256 i = 0; i <= delegationToCounterPerHash[toHash] - 1; i++){
             if (globalHash == delegateToHashes[toHash][i].delegationGlobalHash) {
                 delegationsPerUser[count1] = i;
-                count1=count1+1;
+                count1 = count1 + 1;
             }
         }
-        if (count1>0) {
-        for (uint256 j=0; j<=delegationsPerUser.length-1; j++) {
-            uint256 temp1;
-            uint256 temp2;
-            temp1 = delegationsPerUser[delegationsPerUser.length-1-j];
-            temp2 = delegateToHashes[toHash].length-1;
-            delegateToHashes[toHash][temp1] = delegateToHashes[toHash][temp2];
-            delegateToHashes[toHash].pop();
-            delegationToCounterPerHash[toHash] = delegationToCounterPerHash[toHash] - 1;
+
+        if (count1 > 0) {
+            for (uint256 j = 0; j <= delegationsPerUser.length - 1; j++) {
+                uint256 temp1;
+                uint256 temp2;
+                temp1 = delegationsPerUser[delegationsPerUser.length - 1 - j];
+                temp2 = delegateToHashes[toHash].length - 1;
+                delegateToHashes[toHash][temp1] = delegateToHashes[toHash][temp2];
+                delegateToHashes[toHash].pop();
+                delegationToCounterPerHash[toHash] = delegationToCounterPerHash[toHash] - 1;
+            }
         }
-        }
+
         // delete from fromHashes mapping
-        uint256 countFrom=0;
-        for (uint256 i=0; i<=delegationFromCounterPerHash[fromHash]-1; i++){
+        uint256 countFrom = 0;
+        for (uint256 i = 0; i <= delegationFromCounterPerHash[fromHash] - 1; i++){
             if (globalHash == delegateFromHashes[fromHash][i].delegationGlobalHash) {
-                countFrom=countFrom+1;
+                countFrom = countFrom + 1;
             }
         }
+
         uint256[] memory delegationsFromPerUser = new uint256[](countFrom);
-        uint256 countFrom1=0;
-        for (uint256 i=0; i<=delegationFromCounterPerHash[fromHash]-1; i++){
+        uint256 countFrom1 = 0;
+        for (uint256 i = 0; i <= delegationFromCounterPerHash[fromHash] - 1; i++){
             if (globalHash == delegateFromHashes[fromHash][i].delegationGlobalHash) {
                 delegationsFromPerUser[countFrom1] = i;
-                countFrom1=countFrom1+1;
+                countFrom1 = countFrom1 + 1;
             }
         }
-        if (countFrom1>0) {
-        for (uint256 j=0; j<=delegationsFromPerUser.length-1; j++) {
-            uint256 temp1;
-            uint256 temp2;
-            temp1 = delegationsFromPerUser[delegationsFromPerUser.length-1-j];
-            temp2 = delegateFromHashes[fromHash].length-1;
-            delegateFromHashes[fromHash][temp1] = delegateFromHashes[fromHash][temp2];
-            delegateFromHashes[fromHash].pop();
-            delegationFromCounterPerHash[fromHash] = delegationFromCounterPerHash[fromHash] - 1;
+
+        if (countFrom1 > 0) {
+            for (uint256 j = 0; j <= delegationsFromPerUser.length - 1; j++) {
+                uint256 temp1;
+                uint256 temp2;
+                temp1 = delegationsFromPerUser[delegationsFromPerUser.length - 1 - j];
+                temp2 = delegateFromHashes[fromHash].length - 1;
+                delegateFromHashes[fromHash][temp1] = delegateFromHashes[fromHash][temp2];
+                delegateFromHashes[fromHash].pop();
+                delegationFromCounterPerHash[fromHash] = delegationFromCounterPerHash[fromHash] - 1;
+            }
         }
-        
-        }
-        registeredDelegation[globalHash] =false;
+
+        registeredDelegation[globalHash] = false;
         emit revokeDelegation(msg.sender, _collectionAddress, _delegationAddress, _useCase);
     }
 
     /**
      * @notice Delegator updates a delegation address for a specific use case on a specific NFT collection for a certain duration
-     * 
+     *
      */
     function updateDelegationAddress (address _collectionAddress, address _olddelegationAddress, address _newdelegationAddress, uint256 _expiryDate, uint256 _useCase) public {
         registerDelegationAddress(_collectionAddress, _newdelegationAddress, _expiryDate, _useCase);
@@ -156,30 +160,31 @@ contract delegationManagement {
 
     /**
      * @notice Support function used to retrieve the hash given specific parameters
-     * 
+     *
      */
     function retrieveHash(address _profileAddress, address _collectionAddress, uint256 _useCase) public view returns (bytes32) {
         bytes32 hash;
         hash = keccak256(abi.encodePacked(_profileAddress,_collectionAddress,_useCase));
         return (hash);
     }
-    
+
     /**
      * @notice Returns an array of all delegation addresses (active AND inactive) set by a delegator for a specific use case on a specific NFT collection
-     * 
+     *
      */
      function retrieveToDelegationAddressesPerUsecaseForCollection(address _profileAddress, address _collectionAddress,uint256 _useCase) external view returns (address[] memory ) {
         bytes32 hash;
         hash = keccak256(abi.encodePacked(_profileAddress, _collectionAddress, _useCase));
         address[] memory allDelegations = new address[](delegationToCounterPerHash[hash]);
         uint256 count;
-        count=0;
-        for (uint256 i=0; i<=delegateToHashes[hash].length-1; i++){
+        count = 0;
+        for (uint256 i = 0; i <= delegateToHashes[hash].length - 1; i++){
             if (hash == delegateToHashes[hash][i].delegationToHash) {
                 allDelegations[count] = delegateToHashes[hash][i].delegationAddress;
-                count=count+1;
+                count = count + 1;
             }
         }
+
         return (allDelegations);
     }
 
@@ -187,18 +192,19 @@ contract delegationManagement {
      * @notice Returns an array of all delegators (active AND inactive) for a specific use case on a specific NFT collection
      *
      */
-     function retrieveFromDelegationAddressesPerUsecaseForCollection(address _profileAddress, address _collectionAddress,uint256 _useCase) external view returns (address[] memory ) {
+     function retrieveFromDelegationAddressesPerUsecaseForCollection(address _profileAddress, address _collectionAddress, uint256 _useCase) external view returns (address[] memory ) {
         bytes32 hash;
         hash = keccak256(abi.encodePacked(_profileAddress, _collectionAddress, _useCase));
         address[] memory allDelegations = new address[](delegationFromCounterPerHash[hash]);
         uint256 count;
-        count=0;
-        for (uint256 i=0; i<=delegateFromHashes[hash].length-1; i++){
+        count = 0;
+        for (uint256 i = 0; i <= delegateFromHashes[hash].length - 1; i++){
             if (hash == delegateFromHashes[hash][i].delegationFromHash) {
                 allDelegations[count] = delegateFromHashes[hash][i].mainAddress;
-                count=count+1;
+                count = count + 1;
             }
         }
+
         return (allDelegations);
     }
 
@@ -213,18 +219,19 @@ contract delegationManagement {
         hash = keccak256(abi.encodePacked(_profileAddress, _collectionAddress, _useCase));
         address[] memory allDelegations = new address[](delegationToCounterPerHash[hash]);
         uint256 count;
-        count=0;
-        for (uint256 i=0; i<=delegateToHashes[hash].length-1; i++){
+        count = 0;
+        for (uint256 i = 0; i<=delegateToHashes[hash].length - 1; i++){
             if ((hash == delegateToHashes[hash][i].delegationToHash) && (delegateToHashes[hash][i].expiryDate > _date  )) {
                 allDelegations[count] = delegateToHashes[hash][i].delegationAddress;
-                count=count+1;
+                count = count + 1;
             }
         }
+
         return (allDelegations);
     }
 
     /**
-     * @notice Returns an array of all active delegators on a certain date for a specific use case on a specific NFT collection 
+     * @notice Returns an array of all active delegators on a certain date for a specific use case on a specific NFT collection
      *
     */
 
@@ -233,13 +240,14 @@ contract delegationManagement {
         hash = keccak256(abi.encodePacked(_profileAddress, _collectionAddress, _useCase));
         address[] memory allDelegations = new address[](delegationFromCounterPerHash[hash]);
         uint256 count;
-        count=0;
-        for (uint256 i=0; i<=delegateFromHashes[hash].length-1; i++){
+        count = 0;
+        for (uint256 i = 0; i <= delegateFromHashes[hash].length - 1; i++){
            if ((hash == delegateFromHashes[hash][i].delegationFromHash) && (delegateFromHashes[hash][i].expiryDate > _date  )) {
                 allDelegations[count] = delegateFromHashes[hash][i].mainAddress;
-                count=count+1;
+                count = count + 1;
             }
         }
+
         return (allDelegations);
     }
 }

--- a/src/DelegationManagement.sol
+++ b/src/DelegationManagement.sol
@@ -46,8 +46,8 @@ contract delegationManagement {
     event updateDelegation(address indexed from, address indexed collectionAddress, address olddelegationAddress, address indexed newdelegationAddress, uint256 useCase);
 
     // Constructor
-    constructor() public {
-        useCaseCounter = 15;
+    constructor(uint8 _counter) public {
+        useCaseCounter = _counter;
     }
 
     /**

--- a/src/DelegationManagement.sol
+++ b/src/DelegationManagement.sol
@@ -10,7 +10,7 @@
  *
  */
 
-pragma solidity >=0.6.0 <=0.8.0;
+pragma solidity ^0.8.17;
 
 contract delegationManagement {
 

--- a/src/DelegationManagement.sol
+++ b/src/DelegationManagement.sol
@@ -15,7 +15,7 @@ pragma solidity >=0.6.0 <=0.8.0;
 contract delegationManagement {
 
     // Variable declarations
-    uint256 useCaseCounter;
+    uint8 useCaseCounter;
 
     // Mapping declarations
     mapping (bytes32 => bool) public registeredDelegation;
@@ -55,7 +55,7 @@ contract delegationManagement {
      *
      */
     function registerDelegationAddress(address _collectionAddress, address _delegationAddress, uint256 _expiryDate, uint256 _useCase) public {
-        require((_useCase > 0 && _useCase < useCaseCounter) || (_useCase == 99));
+        require((_useCase > 0 && _useCase < useCaseCounter) || (_useCase == 255));
         bytes32 toHash;
         bytes32 fromHash;
         bytes32 globalHash;


### PR DESCRIPTION
A full uint256 isn't needed for the dates and the use case (unless we have more use cases than atoms in the universe :) ).

Save six storage slots per delegation by packing these as uint96s next to each address (160 + 96 = 256).

Gas before this change is 541,555 (https://goerli.etherscan.io/tx/0xd44e28fe97d73008e8924cce53c74dcdb08b41d229d51a337c1fcad9f8d24ced)

After the change is 408,183 (https://goerli.etherscan.io/tx/0x2b470a99b18a61ce41440b86f80a53ea627e7294d3fc6210f95d890737700b50)