### PR TITLE
Fix from and to address assignments

### DIFF
--- a/src/DelegationManagement.sol
+++ b/src/DelegationManagement.sol
@@ -83,8 +83,8 @@ contract delegationManagement {
         bytes32 globalHash;
         uint256 count;
         globalHash = keccak256(abi.encodePacked(msg.sender, _collectionAddress, _delegationAddress, _useCase));
-        toHash = keccak256(abi.encodePacked(msg.sender, _collectionAddress, _useCase));
-        fromHash = keccak256(abi.encodePacked(_delegationAddress, _collectionAddress, _useCase));
+        fromHash = keccak256(abi.encodePacked(msg.sender, _collectionAddress, _useCase));
+        toHash = keccak256(abi.encodePacked(_delegationAddress, _collectionAddress, _useCase));
         // delete from toHashes mapping
         count=0;
         for (uint256 i=0; i<=delegationToCounterPerHash[toHash]-1; i++){


### PR DESCRIPTION
"From" should be the delegator's address. 

"To" should be the delegated address. 

If i'm not mistaken... The delegator is the one who creates the delegation, and signs the contract. 

So this PR should help straighten it out? 

This creates the "from" has value first, then the "to" hash, to follow the logical progression of how one might think about setting up a delegation. 

Addresses #17. 