### PR TITLE
Styles the code with consistent conventions.

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,15 @@
+{
+    "overrides": [
+      {
+        "files": "*.sol",
+        "options": {
+          "printWidth": 140,
+          "tabWidth": 4,
+          "useTabs": false,
+          "singleQuote": false,
+          "bracketSpacing": false,
+          "explicitTypes": "preserve"
+        }
+      }
+    ]
+  }

--- a/src/DelegationManagement.sol
+++ b/src/DelegationManagement.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-/** 
+/**
  *
  *  @title: Delegation Management Contract
  *  @date: 24-Mar-2022 @ 13:05
@@ -15,13 +15,17 @@
 pragma solidity ^0.8.17;
 
 contract DelegationManagementContract {
+    // Constant declarations
+    address constant ALL_COLLECTIONS = 0x8888888888888888888888888888888888888888;
+    uint8 constant USE_CASE_SUB_DELEGATION = 16;
+    uint8 constant USE_CASE_CONSOLIDATION = 99;
 
     // Variable declarations
     uint256 useCaseCounter;
 
     // Mapping declarations
-    mapping (bytes32 => address[]) public delegatorHashes;
-    mapping (bytes32 => address[]) public delegationAddressHashes;
+    mapping(bytes32 => address[]) public delegatorHashes;
+    mapping(bytes32 => address[]) public delegationAddressHashes;
 
     struct GlobalData {
         uint256 registeredDate;
@@ -31,37 +35,37 @@ contract DelegationManagementContract {
     }
 
     // Mapping of GlobalData struct declaration
-    mapping (bytes32 => GlobalData[]) public globalDelegationHashes;
+    mapping(bytes32 => GlobalData[]) public globalDelegationHashes;
 
     // Events declaration
-    event RegisterDelegation(address indexed from, address indexed collectionAddress, address indexed delegationAddress, uint8 useCase, bool allTokens, uint256 _tokenid);
-    event RegisterDelegationUsingSubDelegation(address indexed delegator, address from, address indexed collectionAddress, address indexed delegationAddress, uint8 useCase, bool allTokens, uint256 _tokenid);
+    event RegisterDelegation(address indexed from, address indexed collectionAddress, address indexed delegationAddress, uint8 useCase, bool allTokens, uint256 _tokenId);
+    event RegisterDelegationUsingSubDelegation(address indexed delegator, address from, address indexed collectionAddress, address indexed delegationAddress, uint8 useCase, bool allTokens, uint256 _tokenId);
     event RevokeDelegation(address indexed from, address indexed collectionAddress, address indexed delegationAddress, uint8 useCase);
     event RevokeDelegationUsingSubDelegation(address indexed delegator, address from, address indexed collectionAddress, address indexed delegationAddress, uint8 useCase);
-    event UpdateDelegation(address indexed from, address indexed collectionAddress, address olddelegationAddress, address indexed newdelegationAddress, uint8 useCase, bool allTokens, uint256 _tokenid);
-    
+    event UpdateDelegation(address indexed from, address indexed collectionAddress, address olddelegationAddress, address indexed newdelegationAddress, uint8 useCase, bool allTokens, uint256 _tokenId);
+
     // Registry for all collections & usecases for a Delegator
-    mapping (address => address[]) public collectionsRegistered;
-    mapping (address => uint256[]) public useCaseRegistered;
+    mapping(address => address[]) public collectionsRegistered;
+    mapping(address => uint256[]) public useCaseRegistered;
 
     // Locks declarations
-    mapping (address => bool) public globalLock;
-    mapping (bytes32 => bool) public collectionLock;
-    mapping (bytes32 => bool) public collectionUsecaseLock;
-    
+    mapping(address => bool) public globalLock;
+    mapping(bytes32 => bool) public collectionLock;
+    mapping(bytes32 => bool) public collectionUsecaseLock;
+
     // Constructor
     constructor() {
         useCaseCounter = 17;
     }
-  
+
     /**
      * @notice Delegator assigns a delegation address for a specific use case on a specific NFT collection for a certain duration
-     * @notice _collectionAddress --> 0x8888888888888888888888888888888888888888 = All collections
+     * @notice _collectionAddress --> ALL_COLLECTIONS = Applies to all collections
      * @notice For all Tokens-- > _allTokens needs to be true, _tokenId does not matter
      */
 
-    function registerDelegationAddress(address _collectionAddress, address _delegationAddress, uint256 _expiryDate, uint8 _useCase, bool _allTokens, uint256 _tokenid) public {
-        require((_useCase >0 && _useCase < useCaseCounter) || (_useCase == 99));
+    function registerDelegationAddress(address _collectionAddress, address _delegationAddress, uint256 _expiryDate, uint8 _useCase, bool _allTokens, uint256 _tokenId) public {
+        require((_useCase > 0 && _useCase < useCaseCounter) || (_useCase == USE_CASE_CONSOLIDATION));
         bytes32 delegatorHash;
         bytes32 delegationAddressHash;
         bytes32 globalHash;
@@ -89,10 +93,10 @@ contract DelegationManagementContract {
             GlobalData memory newdelegationGlobalData = GlobalData(block.timestamp, _expiryDate, true, 0);
             globalDelegationHashes[globalHash].push(newdelegationGlobalData);
         } else {
-            GlobalData memory newdelegationGlobalData = GlobalData(block.timestamp, _expiryDate, false, _tokenid);
+            GlobalData memory newdelegationGlobalData = GlobalData(block.timestamp, _expiryDate, false, _tokenId);
             globalDelegationHashes[globalHash].push(newdelegationGlobalData);
         }
-        emit RegisterDelegation(msg.sender, _collectionAddress, _delegationAddress, _useCase, _allTokens, _tokenid);
+        emit RegisterDelegation(msg.sender, _collectionAddress, _delegationAddress, _useCase, _allTokens, _tokenId);
     }
 
     /**
@@ -100,36 +104,36 @@ contract DelegationManagementContract {
      * @notice A delegation Address that has subDelegation rights given by a Delegator can register Delegations on behalf of Delegator
      */
 
-    function registerDelegationAddressUsingSubDelegation(address _delegatorAddress, address _collectionAddress, address _delegationAddress, uint256 _expiryDate, uint8 _useCase, bool _allTokens, uint256 _tokenid) public {
+    function registerDelegationAddressUsingSubDelegation(address _delegatorAddress, address _collectionAddress, address _delegationAddress, uint256 _expiryDate, uint8 _useCase, bool _allTokens, uint256 _tokenId) public {
         // Check subdelegation rights for the specific collection
         {
-        bool subdelegationRightsCol;
-        address[] memory allDelegators = retrieveDelegators(msg.sender, _collectionAddress, 16);
-        if (allDelegators.length > 0) {
-        for (uint i=0; i<allDelegators.length; i++) {
-            if (_delegatorAddress == allDelegators[i]) {
-                subdelegationRightsCol = true;
-                break;
-            }
-        }
-        }
-        // Check subdelegation rights for All collections
-        allDelegators = retrieveDelegators(msg.sender, 0x8888888888888888888888888888888888888888, 16);
-        if (allDelegators.length > 0) {
-            if (subdelegationRightsCol != true) {
-                for (uint i=0; i<allDelegators.length; i++) {
+            bool subdelegationRightsCol;
+            address[] memory allDelegators = retrieveDelegators(msg.sender, _collectionAddress, USE_CASE_SUB_DELEGATION);
+            if (allDelegators.length > 0) {
+                for (uint i = 0; i < allDelegators.length; i++) {
                     if (_delegatorAddress == allDelegators[i]) {
                         subdelegationRightsCol = true;
                         break;
                     }
                 }
             }
-        }
-        // Allow to register
-        require ((subdelegationRightsCol == true));
+            // Check subdelegation rights for All collections
+            allDelegators = retrieveDelegators(msg.sender, ALL_COLLECTIONS, USE_CASE_SUB_DELEGATION);
+            if (allDelegators.length > 0) {
+                if (subdelegationRightsCol != true) {
+                    for (uint i = 0; i < allDelegators.length; i++) {
+                        if (_delegatorAddress == allDelegators[i]) {
+                            subdelegationRightsCol = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            // Allow to register
+            require((subdelegationRightsCol == true));
         }
         // If check passed then register delegation address for Delegator
-        require((_useCase >0 && _useCase < useCaseCounter) || (_useCase == 99));
+        require((_useCase > 0 && _useCase < useCaseCounter) || (_useCase == USE_CASE_CONSOLIDATION));
         bytes32 delegatorHash;
         bytes32 delegationAddressHash;
         bytes32 globalHash;
@@ -157,17 +161,17 @@ contract DelegationManagementContract {
             GlobalData memory newdelegationGlobalData = GlobalData(block.timestamp, _expiryDate, true, 0);
             globalDelegationHashes[globalHash].push(newdelegationGlobalData);
         } else {
-            GlobalData memory newdelegationGlobalData = GlobalData(block.timestamp, _expiryDate, false, _tokenid);
+            GlobalData memory newdelegationGlobalData = GlobalData(block.timestamp, _expiryDate, false, _tokenId);
             globalDelegationHashes[globalHash].push(newdelegationGlobalData);
         }
-        emit RegisterDelegationUsingSubDelegation(_delegatorAddress, msg.sender, _collectionAddress, _delegationAddress, _useCase, _allTokens, _tokenid);
+        emit RegisterDelegationUsingSubDelegation(_delegatorAddress, msg.sender, _collectionAddress, _delegationAddress, _useCase, _allTokens, _tokenId);
     }
 
     /**
      * @notice Delegator revokes delegation rights given to a delegation address on a specific use case on a specific NFT collection
      * @notice This function does not remove the delegation from the collectionsRegistered or useCaseRegistered as we want to track delegations history
      */
-    
+
     function revokeDelegationAddress(address _collectionAddress, address _delegationAddress, uint8 _useCase) public {
         bytes32 delegatorHash;
         bytes32 delegationAddressHash;
@@ -177,52 +181,52 @@ contract DelegationManagementContract {
         delegatorHash = keccak256(abi.encodePacked(msg.sender, _collectionAddress, _useCase));
         delegationAddressHash = keccak256(abi.encodePacked(_delegationAddress, _collectionAddress, _useCase));
         // Revoke delegation Address from the delegatorHashes mapping
-        count=0;
-        if (delegatorHashes[delegatorHash].length>0) {
-            for (uint256 i=0; i<=delegatorHashes[delegatorHash].length-1; i++){
+        count = 0;
+        if (delegatorHashes[delegatorHash].length > 0) {
+            for (uint256 i = 0; i <= delegatorHashes[delegatorHash].length - 1; i++) {
                 if (_delegationAddress == delegatorHashes[delegatorHash][i]) {
-                    count=count+1;
+                    count = count + 1;
                 }
             }
             uint256[] memory delegationsPerUser = new uint256[](count);
-            uint256 count1=0;
-            for (uint256 i=0; i<=delegatorHashes[delegatorHash].length-1; i++){
+            uint256 count1 = 0;
+            for (uint256 i = 0; i <= delegatorHashes[delegatorHash].length - 1; i++) {
                 if (_delegationAddress == delegatorHashes[delegatorHash][i]) {
                     delegationsPerUser[count1] = i;
-                    count1=count1+1;
+                    count1 = count1 + 1;
                 }
             }
-            if (count1>0) {
-                for (uint256 j=0; j<=delegationsPerUser.length-1; j++) {
+            if (count1 > 0) {
+                for (uint256 j = 0; j <= delegationsPerUser.length - 1; j++) {
                     uint256 temp1;
                     uint256 temp2;
-                    temp1 = delegationsPerUser[delegationsPerUser.length-1-j];
-                    temp2 = delegatorHashes[delegatorHash].length-1;
+                    temp1 = delegationsPerUser[delegationsPerUser.length - 1 - j];
+                    temp2 = delegatorHashes[delegatorHash].length - 1;
                     delegatorHashes[delegatorHash][temp1] = delegatorHashes[delegatorHash][temp2];
                     delegatorHashes[delegatorHash].pop();
                 }
             }
             // Revoke delegator Address from the delegationAddressHashes mapping
-            uint256 countDA=0;
-            for (uint256 i=0; i<=delegationAddressHashes[delegationAddressHash].length-1; i++){
+            uint256 countDA = 0;
+            for (uint256 i = 0; i <= delegationAddressHashes[delegationAddressHash].length - 1; i++) {
                 if (msg.sender == delegationAddressHashes[delegationAddressHash][i]) {
-                    countDA=countDA+1;
+                    countDA = countDA + 1;
                 }
             }
             uint256[] memory delegatorsPerUser = new uint256[](countDA);
-            uint256 countDA1=0;
-            for (uint256 i=0; i<=delegationAddressHashes[delegationAddressHash].length-1; i++){
+            uint256 countDA1 = 0;
+            for (uint256 i = 0; i <= delegationAddressHashes[delegationAddressHash].length - 1; i++) {
                 if (msg.sender == delegationAddressHashes[delegationAddressHash][i]) {
                     delegatorsPerUser[countDA1] = i;
-                    countDA1=countDA1+1;
+                    countDA1 = countDA1 + 1;
                 }
             }
-            if (countDA1>0) {
-                for (uint256 j=0; j<=delegatorsPerUser.length-1; j++) {
+            if (countDA1 > 0) {
+                for (uint256 j = 0; j <= delegatorsPerUser.length - 1; j++) {
                     uint256 temp1;
                     uint256 temp2;
-                    temp1 = delegatorsPerUser[delegatorsPerUser.length-1-j];
-                    temp2 = delegationAddressHashes[delegationAddressHash].length-1;
+                    temp1 = delegatorsPerUser[delegatorsPerUser.length - 1 - j];
+                    temp2 = delegationAddressHashes[delegationAddressHash].length - 1;
                     delegationAddressHashes[delegationAddressHash][temp1] = delegationAddressHashes[delegationAddressHash][temp2];
                     delegationAddressHashes[delegationAddressHash].pop();
                 }
@@ -236,14 +240,14 @@ contract DelegationManagementContract {
     /**
      * @notice This function supports the revoking of a Delegation Address using an address with Subdelegation rights
      */
-    
+
     function revokeDelegationAddressUsingSubdelegation(address _delegatorAddress, address _collectionAddress, address _delegationAddress, uint8 _useCase) public {
         // Check subdelegation rights for the specific collection
         {
             bool subdelegationRightsCol;
-            address[] memory allDelegators = retrieveDelegators(msg.sender, _collectionAddress, 16);
+            address[] memory allDelegators = retrieveDelegators(msg.sender, _collectionAddress, USE_CASE_SUB_DELEGATION);
             if (allDelegators.length > 0) {
-                for (uint i=0; i<allDelegators.length; i++) {
+                for (uint i = 0; i < allDelegators.length; i++) {
                     if (_delegatorAddress == allDelegators[i]) {
                         subdelegationRightsCol = true;
                         break;
@@ -251,10 +255,10 @@ contract DelegationManagementContract {
                 }
             }
             // Check subdelegation rights for All collections
-            allDelegators = retrieveDelegators(msg.sender, 0x8888888888888888888888888888888888888888, 16);
+            allDelegators = retrieveDelegators(msg.sender, ALL_COLLECTIONS, USE_CASE_SUB_DELEGATION);
             if (allDelegators.length > 0) {
                 if (subdelegationRightsCol != true) {
-                    for (uint i=0; i<allDelegators.length; i++) {
+                    for (uint i = 0; i < allDelegators.length; i++) {
                         if (_delegatorAddress == allDelegators[i]) {
                             subdelegationRightsCol = true;
                             break;
@@ -263,59 +267,59 @@ contract DelegationManagementContract {
                 }
             }
             // Allow to revoke
-            require ((subdelegationRightsCol == true));
+            require((subdelegationRightsCol == true));
         }
         // If check passed then revoke delegation address for Delegator
         bytes32 delegatorHash = keccak256(abi.encodePacked(_delegatorAddress, _collectionAddress, _useCase));
         bytes32 delegationAddressHash = keccak256(abi.encodePacked(_delegationAddress, _collectionAddress, _useCase));
-        bytes32 globalHash = keccak256(abi.encodePacked(_delegatorAddress, _collectionAddress, _delegationAddress, _useCase)); 
+        bytes32 globalHash = keccak256(abi.encodePacked(_delegatorAddress, _collectionAddress, _delegationAddress, _useCase));
         uint256 count;
-        count=0;
-        if (delegatorHashes[delegatorHash].length>0) {
-            for (uint256 i=0; i<=delegatorHashes[delegatorHash].length-1; i++){
+        count = 0;
+        if (delegatorHashes[delegatorHash].length > 0) {
+            for (uint256 i = 0; i <= delegatorHashes[delegatorHash].length - 1; i++) {
                 if (_delegationAddress == delegatorHashes[delegatorHash][i]) {
-                    count=count+1;
+                    count = count + 1;
                 }
             }
             uint256[] memory delegationsPerUser = new uint256[](count);
-            uint256 count1=0;
-            for (uint256 i=0; i<=delegatorHashes[delegatorHash].length-1; i++){
+            uint256 count1 = 0;
+            for (uint256 i = 0; i <= delegatorHashes[delegatorHash].length - 1; i++) {
                 if (_delegationAddress == delegatorHashes[delegatorHash][i]) {
                     delegationsPerUser[count1] = i;
-                    count1=count1+1;
+                    count1 = count1 + 1;
                 }
             }
-            if (count1>0) {
-                for (uint256 j=0; j<=delegationsPerUser.length-1; j++) {
+            if (count1 > 0) {
+                for (uint256 j = 0; j <= delegationsPerUser.length - 1; j++) {
                     uint256 temp1;
                     uint256 temp2;
-                    temp1 = delegationsPerUser[delegationsPerUser.length-1-j];
-                    temp2 = delegatorHashes[delegatorHash].length-1;
+                    temp1 = delegationsPerUser[delegationsPerUser.length - 1 - j];
+                    temp2 = delegatorHashes[delegatorHash].length - 1;
                     delegatorHashes[delegatorHash][temp1] = delegatorHashes[delegatorHash][temp2];
                     delegatorHashes[delegatorHash].pop();
                 }
             }
-        // Revoke delegator Address from the delegationAddressHashes mapping
-            uint256 countDA=0;
-            for (uint256 i=0; i<=delegationAddressHashes[delegationAddressHash].length-1; i++){
+            // Revoke delegator Address from the delegationAddressHashes mapping
+            uint256 countDA = 0;
+            for (uint256 i = 0; i <= delegationAddressHashes[delegationAddressHash].length - 1; i++) {
                 if (_delegatorAddress == delegationAddressHashes[delegationAddressHash][i]) {
-                    countDA=countDA+1;
+                    countDA = countDA + 1;
                 }
             }
             uint256[] memory delegatorsPerUser = new uint256[](countDA);
-            uint256 countDA1=0;
-            for (uint256 i=0; i<=delegationAddressHashes[delegationAddressHash].length-1; i++){
+            uint256 countDA1 = 0;
+            for (uint256 i = 0; i <= delegationAddressHashes[delegationAddressHash].length - 1; i++) {
                 if (_delegatorAddress == delegationAddressHashes[delegationAddressHash][i]) {
                     delegatorsPerUser[countDA1] = i;
-                    countDA1=countDA1+1;
+                    countDA1 = countDA1 + 1;
                 }
             }
-            if (countDA1>0) {
-                for (uint256 j=0; j<=delegatorsPerUser.length-1; j++) {
+            if (countDA1 > 0) {
+                for (uint256 j = 0; j <= delegatorsPerUser.length - 1; j++) {
                     uint256 temp1;
                     uint256 temp2;
-                    temp1 = delegatorsPerUser[delegatorsPerUser.length-1-j];
-                    temp2 = delegationAddressHashes[delegationAddressHash].length-1;
+                    temp1 = delegatorsPerUser[delegatorsPerUser.length - 1 - j];
+                    temp2 = delegationAddressHashes[delegationAddressHash].length - 1;
                     delegationAddressHashes[delegationAddressHash][temp1] = delegationAddressHashes[delegationAddressHash][temp2];
                     delegationAddressHashes[delegationAddressHash].pop();
                 }
@@ -332,7 +336,7 @@ contract DelegationManagementContract {
 
     function batchRevocations(address[] memory _collectionAddresses, address[] memory _delegationAddresses, uint8[] memory _useCases) public {
         require(_collectionAddresses.length < 6);
-        for (uint256 i=0; i<=_collectionAddresses.length-1; i++) {
+        for (uint256 i = 0; i <= _collectionAddresses.length - 1; i++) {
             revokeDelegationAddress(_collectionAddresses[i], _delegationAddresses[i], _useCases[i]);
         }
     }
@@ -341,20 +345,20 @@ contract DelegationManagementContract {
      * @notice Delegator updates a delegation address for a specific use case on a specific NFT collection for a certain duration
      */
 
-    function updateDelegationAddress(address _collectionAddress, address _olddelegationAddress, address _newdelegationAddress, uint256 _expiryDate, uint8 _useCase, bool _allTokens, uint256 _tokenid) public {
+    function updateDelegationAddress(address _collectionAddress, address _olddelegationAddress, address _newdelegationAddress, uint256 _expiryDate, uint8 _useCase, bool _allTokens, uint256 _tokenId) public {
         revokeDelegationAddress(_collectionAddress, _olddelegationAddress, _useCase);
-        registerDelegationAddress(_collectionAddress, _newdelegationAddress, _expiryDate, _useCase, _allTokens, _tokenid);
-        emit UpdateDelegation(msg.sender, _collectionAddress, _olddelegationAddress, _newdelegationAddress, _useCase, _allTokens, _tokenid);
+        registerDelegationAddress(_collectionAddress, _newdelegationAddress, _expiryDate, _useCase, _allTokens, _tokenId);
+        emit UpdateDelegation(msg.sender, _collectionAddress, _olddelegationAddress, _newdelegationAddress, _useCase, _allTokens, _tokenId);
     }
 
     /**
      * @notice Batch registrations function (up to 5 delegation addresses)
      */
 
-    function batchDelegations(address[] memory _collectionAddresses, address[] memory _delegationAddresses, uint256[] memory _expiryDates, uint8[] memory _useCases, bool[] memory _allTokens, uint256[] memory _tokenids) public {
+    function batchDelegations(address[] memory _collectionAddresses, address[] memory _delegationAddresses, uint256[] memory _expiryDates, uint8[] memory _useCases, bool[] memory _allTokens, uint256[] memory _tokenIds) public {
         require(_collectionAddresses.length < 6);
-        for (uint256 i=0; i<=_collectionAddresses.length-1; i++) {
-            registerDelegationAddress(_collectionAddresses[i], _delegationAddresses[i], _expiryDates[i], _useCases[i], _allTokens[i], _tokenids[i]);
+        for (uint256 i = 0; i <= _collectionAddresses.length - 1; i++) {
+            registerDelegationAddress(_collectionAddresses[i], _delegationAddresses[i], _expiryDates[i], _useCases[i], _allTokens[i], _tokenIds[i]);
         }
     }
 
@@ -393,7 +397,7 @@ contract DelegationManagementContract {
     function retrieveGlobalLockStatus(address _delegationAddress) public view returns (bool) {
         return globalLock[_delegationAddress];
     }
-    
+
     /**
      * @notice Retrieve Collection Lock Status
      */
@@ -433,12 +437,12 @@ contract DelegationManagementContract {
         globalHash = keccak256(abi.encodePacked(_delegatorAddress, _collectionAddress, _delegationAddress, _useCase));
         return (globalHash);
     }
-    
+
     /**
      * @notice Returns an array of all delegation addresses (active AND inactive) assigned by a delegator for a specific use case on a specific NFT collection
      */
 
-    function retrieveDelegationAddresses(address _delegatorAddress, address _collectionAddress,uint8 _useCase) public view returns (address[] memory ) {
+    function retrieveDelegationAddresses(address _delegatorAddress, address _collectionAddress, uint8 _useCase) public view returns (address[] memory) {
         bytes32 hash;
         hash = keccak256(abi.encodePacked(_delegatorAddress, _collectionAddress, _useCase));
         return (delegatorHashes[hash]);
@@ -448,7 +452,7 @@ contract DelegationManagementContract {
      * @notice Returns an array of all delegators (active AND inactive) that delegated to a delegationAddress for a specific use case on a specific NFT collection
      */
 
-    function retrieveDelegators(address _delegationAddress, address _collectionAddress,uint8 _useCase) public view returns (address[] memory ) {
+    function retrieveDelegators(address _delegationAddress, address _collectionAddress, uint8 _useCase) public view returns (address[] memory) {
         bytes32 hash;
         hash = keccak256(abi.encodePacked(_delegationAddress, _collectionAddress, _useCase));
         return (delegationAddressHashes[hash]);
@@ -458,7 +462,7 @@ contract DelegationManagementContract {
      * @notice Returns all collections and usecases history given a delegator address
      */
 
-    function retrieveFullHistoryOfDelegator(address _delegatorAddress) public view returns (address[] memory, uint256[] memory ) {
+    function retrieveFullHistoryOfDelegator(address _delegatorAddress) public view returns (address[] memory, uint256[] memory) {
         return (collectionsRegistered[_delegatorAddress], useCaseRegistered[_delegatorAddress]);
     }
 
@@ -466,17 +470,17 @@ contract DelegationManagementContract {
      * @notice Returns the active collections and usecases history given a delegator address
      */
 
-    function retrieveActiveHistoryOfDelegator(address _delegatorAddress) public view returns (address[] memory, uint256[] memory ) {
+    function retrieveActiveHistoryOfDelegator(address _delegatorAddress) public view returns (address[] memory, uint256[] memory) {
         address[] memory activeCollections = new address[](collectionsRegistered[_delegatorAddress].length);
         uint256[] memory activeUseCases = new uint256[](useCaseRegistered[_delegatorAddress].length);
-        uint256 count=0;
+        uint256 count = 0;
         bytes32 hash;
-        for (uint256 i=0; i<=collectionsRegistered[_delegatorAddress].length-1; i++) {
+        for (uint256 i = 0; i <= collectionsRegistered[_delegatorAddress].length - 1; i++) {
             hash = keccak256(abi.encodePacked(_delegatorAddress, collectionsRegistered[_delegatorAddress][i], uint8(useCaseRegistered[_delegatorAddress][i])));
             if (delegatorHashes[hash].length > 0) {
                 activeCollections[count] = collectionsRegistered[_delegatorAddress][i];
                 activeUseCases[count] = useCaseRegistered[_delegatorAddress][i];
-                count = count +1;
+                count = count + 1;
             }
         }
         return (activeCollections, activeUseCases);
@@ -487,10 +491,10 @@ contract DelegationManagementContract {
      * @notice false means that the cold wallet did not register a delegation or the delegation was revoked from the delegatorHashes mapping
      */
 
-    function retrieveDelegatorStatusOfDelegation(address _delegatorAddress, address _collectionAddress,uint8 _useCase) public view returns (bool) {
+    function retrieveDelegatorStatusOfDelegation(address _delegatorAddress, address _collectionAddress, uint8 _useCase) public view returns (bool) {
         bytes32 hash;
         hash = keccak256(abi.encodePacked(_delegatorAddress, _collectionAddress, _useCase));
-        if (delegatorHashes[hash].length >0) {
+        if (delegatorHashes[hash].length > 0) {
             return true;
         } else {
             return false;
@@ -502,10 +506,10 @@ contract DelegationManagementContract {
      * @notice false means that a delegation address is not registered or it was revoked from the delegationAddressHashes mapping
      */
 
-    function retrieveDelegationAddressStatusOfDelegation(address _delegationAddress, address _collectionAddress,uint8 _useCase) public view returns (bool) {
+    function retrieveDelegationAddressStatusOfDelegation(address _delegationAddress, address _collectionAddress, uint8 _useCase) public view returns (bool) {
         bytes32 hash;
         hash = keccak256(abi.encodePacked(_delegationAddress, _collectionAddress, _useCase));
-        if (delegationAddressHashes[hash].length >0) {
+        if (delegationAddressHashes[hash].length > 0) {
             return true;
         } else {
             return false;
@@ -519,7 +523,7 @@ contract DelegationManagementContract {
     function retrieveGlobalStatusOfDelegation(address _delegatorAddress, address _collectionAddress, address _delegationAddress, uint8 _useCase) public view returns (bool) {
         bytes32 hash;
         hash = keccak256(abi.encodePacked(_delegatorAddress, _collectionAddress, _delegationAddress, _useCase));
-        if (globalDelegationHashes[hash].length >0) {
+        if (globalDelegationHashes[hash].length > 0) {
             return true;
         } else {
             return false;
@@ -530,20 +534,20 @@ contract DelegationManagementContract {
      * @notice Returns the status of a delegation given the delegator address, the collection address, the delegation address as well as a specific token id
      */
 
-    function retrieveTokenStatus(address _delegatorAddress, address _collectionAddress, address _delegationAddress, uint8 _useCase, uint256 _tokenid) public view returns (bool) {
+    function retrieveTokenStatus(address _delegatorAddress, address _collectionAddress, address _delegationAddress, uint8 _useCase, uint256 _tokenId) public view returns (bool) {
         bytes32 hash;
         hash = keccak256(abi.encodePacked(_delegatorAddress, _collectionAddress, _delegationAddress, _useCase));
         bool status;
         if (globalDelegationHashes[hash].length > 0) {
-            for (uint256 i=0; i<= globalDelegationHashes[hash].length-1; i++) {
-                if ((globalDelegationHashes[hash][i].allTokens == false) && (globalDelegationHashes[hash][i].tokens == _tokenid)) {
+            for (uint256 i = 0; i <= globalDelegationHashes[hash].length - 1; i++) {
+                if ((globalDelegationHashes[hash][i].allTokens == false) && (globalDelegationHashes[hash][i].tokens == _tokenId)) {
                     status = true;
                     break;
                 } else {
                     status = false;
                 }
             }
-            return status; 
+            return status;
         } else {
             return false;
         }
@@ -554,7 +558,7 @@ contract DelegationManagementContract {
      */
 
     function retrieveStatusOfMostRecentDelegation(address _delegatorAddress, address _collectionAddress, address _delegationAddress, uint8 _useCase) public view returns (bool) {
-        if (_delegationAddress == retrieveMostRecentDelegation(_delegatorAddress, _collectionAddress, _useCase)){
+        if (_delegationAddress == retrieveMostRecentDelegation(_delegatorAddress, _collectionAddress, _useCase)) {
             return true;
         } else {
             return false;
@@ -565,11 +569,11 @@ contract DelegationManagementContract {
      * @notice Checks if a delegator granted subdelegation status to an Address
      */
 
-    function retrieveSubDelegationStatus(address _delegatorAddress, address _collectionAddress, address _delegationAddress) public view returns(bool) {
+    function retrieveSubDelegationStatus(address _delegatorAddress, address _collectionAddress, address _delegationAddress) public view returns (bool) {
         bool subdelegationRights;
-        address[] memory allDelegators = retrieveDelegators(_delegationAddress, _collectionAddress, 16);
+        address[] memory allDelegators = retrieveDelegators(_delegationAddress, _collectionAddress, USE_CASE_SUB_DELEGATION);
         if (allDelegators.length > 0) {
-            for (uint i=0; i<=allDelegators.length; i++) {
+            for (uint i = 0; i <= allDelegators.length; i++) {
                 if (_delegatorAddress == allDelegators[i]) {
                     subdelegationRights = true;
                     break;
@@ -590,8 +594,8 @@ contract DelegationManagementContract {
     function retrieveStatusOfActiveDelegator(address _delegatorAddress, address _collectionAddress, address _delegationAddress, uint256 _date, uint8 _useCase) public view returns (bool) {
         address[] memory allActiveDelegators = retrieveActiveDelegators(_delegationAddress, _collectionAddress, _date, _useCase);
         bool status;
-        if (allActiveDelegators.length>0) {
-            for (uint256 i=0; i<= allActiveDelegators.length-1; i++) {
+        if (allActiveDelegators.length > 0) {
+            for (uint256 i = 0; i <= allActiveDelegators.length - 1; i++) {
                 if (_delegatorAddress == allActiveDelegators[i]) {
                     status = true;
                     break;
@@ -599,27 +603,27 @@ contract DelegationManagementContract {
                     status = false;
                 }
             }
-            return status; 
+            return status;
         } else {
             return false;
-        } 
-    } 
+        }
+    }
 
     // Retrieve Delegations delegated by a Delegator
     // This set of functions is used to retrieve info for a Delegator (cold address)
 
-    function retrieveDelegationAddressesTokensIDsandExpiredDates(address _delegatorAddress, address _collectionAddress,uint8 _useCase) public view returns (address[] memory, uint256[] memory, bool[] memory, uint256[] memory) {
+    function retrieveDelegationAddressesTokensIDsandExpiredDates(address _delegatorAddress, address _collectionAddress, uint8 _useCase) public view returns (address[] memory, uint256[] memory, bool[] memory, uint256[] memory) {
         address[] memory allDelegations = retrieveDelegationAddresses(_delegatorAddress, _collectionAddress, _useCase);
         bytes32 globalHash;
         bytes32[] memory allGlobalHashes = new bytes32[](allDelegations.length);
-        uint256 count1 =0 ;
-        uint256 count2 =0 ;
-        uint256 k=0;
-        if (allDelegations.length>0) {
-            for (uint256 i=0; i<=allDelegations.length-1; i++){
+        uint256 count1 = 0;
+        uint256 count2 = 0;
+        uint256 k = 0;
+        if (allDelegations.length > 0) {
+            for (uint256 i = 0; i <= allDelegations.length - 1; i++) {
                 globalHash = keccak256(abi.encodePacked(_delegatorAddress, _collectionAddress, allDelegations[i], _useCase));
                 allGlobalHashes[count1] = globalHash;
-                count1 = count1+1;
+                count1 = count1 + 1;
             }
             //Removes duplicates
             for (uint256 i = 0; i < allGlobalHashes.length - 1; i++) {
@@ -629,16 +633,16 @@ contract DelegationManagementContract {
                     }
                 }
             }
-            for (uint256 i=0; i<=allGlobalHashes.length-1; i++){
+            for (uint256 i = 0; i <= allGlobalHashes.length - 1; i++) {
                 k = globalDelegationHashes[allGlobalHashes[i]].length + k;
             }
-        //Declare local arrays
+            //Declare local arrays
             uint256[] memory tokensIDs = new uint256[](k);
             bool[] memory allTokens = new bool[](k);
             uint256[] memory allExpirations = new uint256[](k);
-            for (uint256 y=0; y<=k-1; y++){
-                if (globalDelegationHashes[allGlobalHashes[y]].length>0) {
-                    for (uint256 w=0; w<=globalDelegationHashes[allGlobalHashes[y]].length-1; w++){
+            for (uint256 y = 0; y <= k - 1; y++) {
+                if (globalDelegationHashes[allGlobalHashes[y]].length > 0) {
+                    for (uint256 w = 0; w <= globalDelegationHashes[allGlobalHashes[y]].length - 1; w++) {
                         allExpirations[count2] = globalDelegationHashes[allGlobalHashes[y]][w].expiryDate;
                         allTokens[count2] = globalDelegationHashes[allGlobalHashes[y]][w].allTokens;
                         tokensIDs[count2] = globalDelegationHashes[allGlobalHashes[y]][w].tokens;
@@ -659,20 +663,20 @@ contract DelegationManagementContract {
     /**
      * @notice Returns an array of all active delegation addresses on a certain date for a specific use case on a specific NFT collection given a delegation Address
      */
-        
+
     function retrieveActiveDelegations(address _delegatorAddress, address _collectionAddress, uint256 _date, uint8 _useCase) public view returns (address[] memory) {
         address[] memory allDelegations = retrieveDelegationAddresses(_delegatorAddress, _collectionAddress, _useCase);
         bytes32 globalHash;
         bytes32[] memory allGlobalHashes = new bytes32[](allDelegations.length);
-        uint256 count1 =0;
-        uint256 count2 =0;
-        uint256 count3 =0;
-        uint256 k=0;
-        if (allDelegations.length>0) {
-            for (uint256 i=0; i<=allDelegations.length-1; i++){
+        uint256 count1 = 0;
+        uint256 count2 = 0;
+        uint256 count3 = 0;
+        uint256 k = 0;
+        if (allDelegations.length > 0) {
+            for (uint256 i = 0; i <= allDelegations.length - 1; i++) {
                 globalHash = keccak256(abi.encodePacked(_delegatorAddress, _collectionAddress, allDelegations[i], _useCase));
                 allGlobalHashes[count1] = globalHash;
-                count1 = count1+1;
+                count1 = count1 + 1;
             }
             //Remove duplicates
             for (uint256 i = 0; i < allGlobalHashes.length - 1; i++) {
@@ -682,27 +686,27 @@ contract DelegationManagementContract {
                     }
                 }
             }
-            for (uint256 i=0; i<=allGlobalHashes.length-1; i++){
+            for (uint256 i = 0; i <= allGlobalHashes.length - 1; i++) {
                 k = globalDelegationHashes[allGlobalHashes[i]].length + k;
             }
             //Declare local arrays
             uint256[] memory allExpirations = new uint256[](k);
-            for (uint256 y=0; y<=k-1; y++){
-                if (globalDelegationHashes[allGlobalHashes[y]].length>0) {
-                    for (uint256 w=0; w<=globalDelegationHashes[allGlobalHashes[y]].length-1; w++){
+            for (uint256 y = 0; y <= k - 1; y++) {
+                if (globalDelegationHashes[allGlobalHashes[y]].length > 0) {
+                    for (uint256 w = 0; w <= globalDelegationHashes[allGlobalHashes[y]].length - 1; w++) {
                         allExpirations[count2] = globalDelegationHashes[allGlobalHashes[y]][w].expiryDate;
                         count2 = count2 + 1;
                     }
                 }
             }
             address[] memory allActive = new address[](allExpirations.length);
-            for (uint256 y=0; y<=k-1; y++){
-                if (allExpirations[y]>_date) {
+            for (uint256 y = 0; y <= k - 1; y++) {
+                if (allExpirations[y] > _date) {
                     allActive[count3] = allDelegations[y];
                     count3 = count3 + 1;
                 }
             }
-            return (allActive); 
+            return (allActive);
         } else {
             address[] memory allActive = new address[](0);
             return (allActive);
@@ -710,21 +714,21 @@ contract DelegationManagementContract {
     }
 
     /**
-     * @notice Returns the most recent delegation address delegated for a specific use case on a specific NFT collection 
+     * @notice Returns the most recent delegation address delegated for a specific use case on a specific NFT collection
      */
 
     function retrieveMostRecentDelegation(address _delegatorAddress, address _collectionAddress, uint8 _useCase) public view returns (address) {
         address[] memory allDelegations = retrieveDelegationAddresses(_delegatorAddress, _collectionAddress, _useCase);
         bytes32 globalHash;
         bytes32[] memory allGlobalHashes = new bytes32[](allDelegations.length);
-        uint256 count1 =0 ;
-        uint256 count2 =0 ;
-        uint256 k=0;
-        if (allDelegations.length>0) {
-            for (uint256 i=0; i<=allDelegations.length-1; i++){
+        uint256 count1 = 0;
+        uint256 count2 = 0;
+        uint256 k = 0;
+        if (allDelegations.length > 0) {
+            for (uint256 i = 0; i <= allDelegations.length - 1; i++) {
                 globalHash = keccak256(abi.encodePacked(_delegatorAddress, _collectionAddress, allDelegations[i], _useCase));
                 allGlobalHashes[count1] = globalHash;
-                count1 = count1+1;
+                count1 = count1 + 1;
             }
             //Removes duplicates
             for (uint256 i = 0; i < allGlobalHashes.length - 1; i++) {
@@ -734,14 +738,14 @@ contract DelegationManagementContract {
                     }
                 }
             }
-            for (uint256 i=0; i<=allGlobalHashes.length-1; i++){
+            for (uint256 i = 0; i <= allGlobalHashes.length - 1; i++) {
                 k = globalDelegationHashes[allGlobalHashes[i]].length + k;
             }
-        //Declare local arrays
+            //Declare local arrays
             uint256[] memory allRegistrations = new uint256[](k);
-            for (uint256 y=0; y<=k-1; y++){
-                if (globalDelegationHashes[allGlobalHashes[y]].length>0) {
-                    for (uint256 w=0; w<=globalDelegationHashes[allGlobalHashes[y]].length-1; w++){
+            for (uint256 y = 0; y <= k - 1; y++) {
+                if (globalDelegationHashes[allGlobalHashes[y]].length > 0) {
+                    for (uint256 w = 0; w <= globalDelegationHashes[allGlobalHashes[y]].length - 1; w++) {
                         allRegistrations[count2] = globalDelegationHashes[allGlobalHashes[y]][w].registeredDate;
                         count2 = count2 + 1;
                     }
@@ -749,8 +753,8 @@ contract DelegationManagementContract {
             }
             address recentDelegationAddress = allDelegations[0];
             uint256 time = allRegistrations[0];
-            for (uint256 i=0; i<=allDelegations.length-1; i++){
-                if (allRegistrations[i] > time){
+            for (uint256 i = 0; i <= allDelegations.length - 1; i++) {
+                if (allRegistrations[i] > time) {
                     time = allRegistrations[i];
                     recentDelegationAddress = allDelegations[i];
                 }
@@ -761,27 +765,27 @@ contract DelegationManagementContract {
         }
     }
 
-    // Retrieve Delegators delegated to a hot wallet 
+    // Retrieve Delegators delegated to a hot wallet
     // This set of functions is used to retrieve info for a hot wallet
 
     /**
      * @notice Returns an array of all token ids delegated by a Delegator for a specific usecase on specific collection given a delegation Address
      */
-     
-    function retrieveDelegatorsTokensIDsandExpiredDates(address _delegationAddress, address _collectionAddress,uint8 _useCase) public view returns (address[] memory, uint256[] memory, bool[] memory, uint256[] memory) {
+
+    function retrieveDelegatorsTokensIDsandExpiredDates(address _delegationAddress, address _collectionAddress, uint8 _useCase) public view returns (address[] memory, uint256[] memory, bool[] memory, uint256[] memory) {
         address[] memory allDelegators = retrieveDelegators(_delegationAddress, _collectionAddress, _useCase);
         bytes32 globalHash;
         bytes32[] memory allGlobalHashes = new bytes32[](allDelegators.length);
-        uint256 count1 =0 ;
-        uint256 count2 =0 ;
-        uint256 k=0;
-        if (allDelegators.length>0) {
-            for (uint256 i=0; i<=allDelegators.length-1; i++){
+        uint256 count1 = 0;
+        uint256 count2 = 0;
+        uint256 k = 0;
+        if (allDelegators.length > 0) {
+            for (uint256 i = 0; i <= allDelegators.length - 1; i++) {
                 globalHash = keccak256(abi.encodePacked(allDelegators[i], _collectionAddress, _delegationAddress, _useCase));
                 allGlobalHashes[count1] = globalHash;
-                count1 = count1+1;
+                count1 = count1 + 1;
             }
-        //Removes duplicates
+            //Removes duplicates
             for (uint256 i = 0; i < allGlobalHashes.length - 1; i++) {
                 for (uint256 j = i + 1; j < allGlobalHashes.length; j++) {
                     if (allGlobalHashes[i] == allGlobalHashes[j]) {
@@ -789,16 +793,16 @@ contract DelegationManagementContract {
                     }
                 }
             }
-            for (uint256 i=0; i<=allGlobalHashes.length-1; i++){
+            for (uint256 i = 0; i <= allGlobalHashes.length - 1; i++) {
                 k = globalDelegationHashes[allGlobalHashes[i]].length + k;
             }
-        //Declare local arrays
+            //Declare local arrays
             uint256[] memory tokensIDs = new uint256[](k);
             bool[] memory allTokens = new bool[](k);
             uint256[] memory allExpirations = new uint256[](k);
-            for (uint256 y=0; y<=k-1; y++){
-                if (globalDelegationHashes[allGlobalHashes[y]].length>0) {
-                    for (uint256 w=0; w<=globalDelegationHashes[allGlobalHashes[y]].length-1; w++){
+            for (uint256 y = 0; y <= k - 1; y++) {
+                if (globalDelegationHashes[allGlobalHashes[y]].length > 0) {
+                    for (uint256 w = 0; w <= globalDelegationHashes[allGlobalHashes[y]].length - 1; w++) {
                         allExpirations[count2] = globalDelegationHashes[allGlobalHashes[y]][w].expiryDate;
                         allTokens[count2] = globalDelegationHashes[allGlobalHashes[y]][w].allTokens;
                         tokensIDs[count2] = globalDelegationHashes[allGlobalHashes[y]][w].tokens;
@@ -818,23 +822,23 @@ contract DelegationManagementContract {
 
     /**
      * @notice Returns an array of all active delegators on a certain date for a specific use case on a specific NFT collection given a delegation Address
-    */
+     */
 
     function retrieveActiveDelegators(address _delegationAddress, address _collectionAddress, uint256 _date, uint8 _useCase) public view returns (address[] memory) {
         address[] memory allDelegators = retrieveDelegators(_delegationAddress, _collectionAddress, _useCase);
         bytes32 globalHash;
         bytes32[] memory allGlobalHashes = new bytes32[](allDelegators.length);
-        uint256 count1 =0;
-        uint256 count2 =0;
-        uint256 count3 =0;
-        uint256 k=0;
-        if (allDelegators.length>0) {
-            for (uint256 i=0; i<=allDelegators.length-1; i++){
+        uint256 count1 = 0;
+        uint256 count2 = 0;
+        uint256 count3 = 0;
+        uint256 k = 0;
+        if (allDelegators.length > 0) {
+            for (uint256 i = 0; i <= allDelegators.length - 1; i++) {
                 globalHash = keccak256(abi.encodePacked(allDelegators[i], _collectionAddress, _delegationAddress, _useCase));
                 allGlobalHashes[count1] = globalHash;
-                count1 = count1+1;
+                count1 = count1 + 1;
             }
-        //Remove duplicates
+            //Remove duplicates
             for (uint256 i = 0; i < allGlobalHashes.length - 1; i++) {
                 for (uint256 j = i + 1; j < allGlobalHashes.length; j++) {
                     if (allGlobalHashes[i] == allGlobalHashes[j]) {
@@ -842,27 +846,27 @@ contract DelegationManagementContract {
                     }
                 }
             }
-            for (uint256 i=0; i<=allGlobalHashes.length-1; i++){
+            for (uint256 i = 0; i <= allGlobalHashes.length - 1; i++) {
                 k = globalDelegationHashes[allGlobalHashes[i]].length + k;
             }
-        //Declare local arrays
+            //Declare local arrays
             uint256[] memory allExpirations = new uint256[](k);
-            for (uint256 y=0; y<=k-1; y++){
-                if (globalDelegationHashes[allGlobalHashes[y]].length>0) {
-                    for (uint256 w=0; w<=globalDelegationHashes[allGlobalHashes[y]].length-1; w++){
+            for (uint256 y = 0; y <= k - 1; y++) {
+                if (globalDelegationHashes[allGlobalHashes[y]].length > 0) {
+                    for (uint256 w = 0; w <= globalDelegationHashes[allGlobalHashes[y]].length - 1; w++) {
                         allExpirations[count2] = globalDelegationHashes[allGlobalHashes[y]][w].expiryDate;
                         count2 = count2 + 1;
                     }
                 }
             }
             address[] memory allActive = new address[](allExpirations.length);
-            for (uint256 y=0; y<=k-1; y++){
-                if (allExpirations[y]>_date) {
+            for (uint256 y = 0; y <= k - 1; y++) {
+                if (allExpirations[y] > _date) {
                     allActive[count3] = allDelegators[y];
                     count3 = count3 + 1;
                 }
             }
-            return (allActive); 
+            return (allActive);
         } else {
             address[] memory allActive = new address[](0);
             return (allActive);
@@ -871,22 +875,22 @@ contract DelegationManagementContract {
 
     /**
      * @notice Returns the most recent delegator for a specific use case on a specific NFT collection given a delegation Address
-    */
+     */
 
     function retrieveMostRecentDelegator(address _delegationAddress, address _collectionAddress, uint8 _useCase) public view returns (address) {
-         address[] memory allDelegators = retrieveDelegators(_delegationAddress, _collectionAddress, _useCase);
+        address[] memory allDelegators = retrieveDelegators(_delegationAddress, _collectionAddress, _useCase);
         bytes32 globalHash;
         bytes32[] memory allGlobalHashes = new bytes32[](allDelegators.length);
-        uint256 count1 =0 ;
-        uint256 count2 =0 ;
-        uint256 k=0;
-        if (allDelegators.length>0) {
-            for (uint256 i=0; i<=allDelegators.length-1; i++){
+        uint256 count1 = 0;
+        uint256 count2 = 0;
+        uint256 k = 0;
+        if (allDelegators.length > 0) {
+            for (uint256 i = 0; i <= allDelegators.length - 1; i++) {
                 globalHash = keccak256(abi.encodePacked(allDelegators[i], _collectionAddress, _delegationAddress, _useCase));
                 allGlobalHashes[count1] = globalHash;
-                count1 = count1+1;
+                count1 = count1 + 1;
             }
-        //Removes duplicates
+            //Removes duplicates
             for (uint256 i = 0; i < allGlobalHashes.length - 1; i++) {
                 for (uint256 j = i + 1; j < allGlobalHashes.length; j++) {
                     if (allGlobalHashes[i] == allGlobalHashes[j]) {
@@ -894,14 +898,14 @@ contract DelegationManagementContract {
                     }
                 }
             }
-            for (uint256 i=0; i<=allGlobalHashes.length-1; i++){
+            for (uint256 i = 0; i <= allGlobalHashes.length - 1; i++) {
                 k = globalDelegationHashes[allGlobalHashes[i]].length + k;
             }
-        //Declare local arrays
+            //Declare local arrays
             uint256[] memory allRegistrations = new uint256[](k);
-            for (uint256 y=0; y<=k-1; y++){
-                if (globalDelegationHashes[allGlobalHashes[y]].length>0) {
-                    for (uint256 w=0; w<=globalDelegationHashes[allGlobalHashes[y]].length-1; w++){
+            for (uint256 y = 0; y <= k - 1; y++) {
+                if (globalDelegationHashes[allGlobalHashes[y]].length > 0) {
+                    for (uint256 w = 0; w <= globalDelegationHashes[allGlobalHashes[y]].length - 1; w++) {
                         allRegistrations[count2] = globalDelegationHashes[allGlobalHashes[y]][w].registeredDate;
                         count2 = count2 + 1;
                     }
@@ -909,8 +913,8 @@ contract DelegationManagementContract {
             }
             address recentDelegatorAddress = allDelegators[0];
             uint256 time = allRegistrations[0];
-            for (uint256 i=0; i<=allDelegators.length-1; i++){
-                if (allRegistrations[i] > time){
+            for (uint256 i = 0; i <= allDelegators.length - 1; i++) {
+                if (allRegistrations[i] > time) {
                     time = allRegistrations[i];
                     recentDelegatorAddress = allDelegators[i];
                 }
@@ -923,20 +927,20 @@ contract DelegationManagementContract {
 
     /**
      * @notice This function checks the Consolidation status between 2 addresses
-    */
+     */
 
-    function checkConsolidationStatus(address _wallet1, address _wallet2, address _collectionAddress) public view returns( bool ) {
-        address[] memory allDelegationsWallet1 = retrieveDelegationAddresses(_wallet1, _collectionAddress, 99);
-        address[] memory allDelegationsWallet2 = retrieveDelegationAddresses(_wallet2, _collectionAddress, 99);
+    function checkConsolidationStatus(address _wallet1, address _wallet2, address _collectionAddress) public view returns (bool) {
+        address[] memory allDelegationsWallet1 = retrieveDelegationAddresses(_wallet1, _collectionAddress, USE_CASE_CONSOLIDATION);
+        address[] memory allDelegationsWallet2 = retrieveDelegationAddresses(_wallet2, _collectionAddress, USE_CASE_CONSOLIDATION);
         bool wallet1Consolidation;
         bool wallet2Consolidation;
-        if (allDelegationsWallet1.length>0 && allDelegationsWallet2.length>0) {
-            for (uint256 i=0; i<=allDelegationsWallet1.length-1; i++) {
+        if (allDelegationsWallet1.length > 0 && allDelegationsWallet2.length > 0) {
+            for (uint256 i = 0; i <= allDelegationsWallet1.length - 1; i++) {
                 if (_wallet2 == allDelegationsWallet1[i]) {
                     wallet1Consolidation = true;
                 }
             }
-            for (uint256 i=0; i<=allDelegationsWallet2.length-1; i++) {
+            for (uint256 i = 0; i <= allDelegationsWallet2.length - 1; i++) {
                 if (_wallet1 == allDelegationsWallet2[i]) {
                     wallet2Consolidation = true;
                 }
@@ -948,5 +952,4 @@ contract DelegationManagementContract {
             return false;
         }
     }
-     
 }


### PR DESCRIPTION
Adds .prettierrc.json so everyone running the project can use the same settings.

This also corrects the capitalization of `tokenid` to `tokenId`. 

Also removes the "Magic Numbers" for the use-case IDs, and the "all" contract addy. These are now constants defined at the top. 