### PR TITLE
Refactor conditionals to reduce code size, improve readability

### DIFF
--- a/src/DelegationManagement.sol
+++ b/src/DelegationManagement.sol
@@ -100,14 +100,11 @@ contract DelegationManagementContract {
         // Store Delegation history
         collectionsRegistered[msg.sender].push(_collectionAddress);
         useCaseRegistered[msg.sender].push(_useCase);
-        // Push additional data to the globalDelegationHashes mapping
-        if (_allTokens == true) {
-            GlobalData memory newdelegationGlobalData = GlobalData(msg.sender, _delegationAddress, block.timestamp, _expiryDate, true, 0);
-            globalDelegationHashes[globalHash].push(newdelegationGlobalData);
-        } else {
-            GlobalData memory newdelegationGlobalData = GlobalData(msg.sender, _delegationAddress, block.timestamp, _expiryDate, false, _tokenId);
-            globalDelegationHashes[globalHash].push(newdelegationGlobalData);
-        }
+        // Push additional data to the globalDelegationHashes mapping, ensuring 0 as _tokenId, if _allTokens is true
+        _tokenId = _allTokens ? 0 : _tokenId;
+        GlobalData memory newdelegationGlobalData = GlobalData(msg.sender, _delegationAddress, block.timestamp, _expiryDate, _allTokens, _tokenId);
+        globalDelegationHashes[globalHash].push(newdelegationGlobalData);
+
         emit RegisterDelegation(msg.sender, _collectionAddress, _delegationAddress, _useCase, _allTokens, _tokenId);
     }
 
@@ -176,14 +173,11 @@ contract DelegationManagementContract {
         // Store Delegation history
         collectionsRegistered[_delegatorAddress].push(_collectionAddress);
         useCaseRegistered[_delegatorAddress].push(_useCase);
-        // Push additional data to the globalDelegationHashes mapping
-        if (_allTokens == true) {
-            GlobalData memory newdelegationGlobalData = GlobalData(msg.sender, _delegationAddress, block.timestamp, _expiryDate, true, 0);
-            globalDelegationHashes[globalHash].push(newdelegationGlobalData);
-        } else {
-            GlobalData memory newdelegationGlobalData = GlobalData(msg.sender, _delegationAddress, block.timestamp, _expiryDate, false, _tokenId);
-            globalDelegationHashes[globalHash].push(newdelegationGlobalData);
-        }
+        // Push additional data to the globalDelegationHashes mapping, ensuring 0 as _tokenId, if _allTokens is true
+        _tokenId = _allTokens ? 0 : _tokenId;
+        GlobalData memory newdelegationGlobalData = GlobalData(msg.sender, _delegationAddress, block.timestamp, _expiryDate, _allTokens, _tokenId);
+        globalDelegationHashes[globalHash].push(newdelegationGlobalData);
+        
         emit RegisterDelegationUsingSubDelegation(_delegatorAddress, msg.sender, _collectionAddress, _delegationAddress, _useCase, _allTokens, _tokenId);
     }
 

--- a/src/DelegationManagement.sol
+++ b/src/DelegationManagement.sol
@@ -606,8 +606,7 @@ contract DelegationManagementContract {
      */
 
     function retrieveTokenStatus(address _delegatorAddress, address _collectionAddress, address _delegationAddress, uint8 _useCase, uint256 _tokenId) public view returns (bool) {
-        bytes32 hash;
-        hash = keccak256(abi.encodePacked(_delegatorAddress, _collectionAddress, _delegationAddress, _useCase));
+        bytes32 hash = keccak256(abi.encodePacked(_delegatorAddress, _collectionAddress, _delegationAddress, _useCase));
 
         for (uint256 i = 0; i < globalDelegationHashes[hash].length; ) {
             if ((globalDelegationHashes[hash][i].allTokens == false) && (globalDelegationHashes[hash][i].tokens == _tokenId)) {

--- a/src/DelegationManagement.sol
+++ b/src/DelegationManagement.sol
@@ -608,24 +608,17 @@ contract DelegationManagementContract {
     function retrieveTokenStatus(address _delegatorAddress, address _collectionAddress, address _delegationAddress, uint8 _useCase, uint256 _tokenId) public view returns (bool) {
         bytes32 hash;
         hash = keccak256(abi.encodePacked(_delegatorAddress, _collectionAddress, _delegationAddress, _useCase));
-        bool status;
-        if (globalDelegationHashes[hash].length > 0) {
-            for (uint256 i = 0; i < globalDelegationHashes[hash].length; ) {
-                if ((globalDelegationHashes[hash][i].allTokens == false) && (globalDelegationHashes[hash][i].tokens == _tokenId)) {
-                    status = true;
-                    break;
-                } else {
-                    status = false;
-                }
 
-                unchecked {
-                    ++i;
-                }
+        for (uint256 i = 0; i < globalDelegationHashes[hash].length; ) {
+            if ((globalDelegationHashes[hash][i].allTokens == false) && (globalDelegationHashes[hash][i].tokens == _tokenId)) {
+                return true;
             }
-            return status;
-        } else {
-            return false;
+            
+            unchecked {
+                ++i;
+            }
         }
+        return false;
     }
 
     /**
@@ -641,51 +634,38 @@ contract DelegationManagementContract {
      */
 
     function retrieveSubDelegationStatus(address _delegatorAddress, address _collectionAddress, address _delegationAddress) public view returns (bool) {
-        bool subdelegationRights;
         address[] memory allDelegators = retrieveDelegators(_delegationAddress, _collectionAddress, USE_CASE_SUB_DELEGATION);
-        if (allDelegators.length > 0) {
-            for (uint i = 0; i < allDelegators.length; ) {
-                if (_delegatorAddress == allDelegators[i]) {
-                    subdelegationRights = true;
-                    break;
-                }
 
-                unchecked {
-                    ++i;
-                }
+        for (uint256 i = 0; i < allDelegators.length; i++) {
+            if (_delegatorAddress == allDelegators[i]) {
+                return true;
+            }
+
+            unchecked {
+                ++i;
             }
         }
-        if (subdelegationRights == true) {
-            return (true);
-        } else {
-            return (false);
-        }
-    }
 
+        return false;
+    }
     /**
      * @notice Checks the status of an active delegator for a delegation Address
      */
 
     function retrieveStatusOfActiveDelegator(address _delegatorAddress, address _collectionAddress, address _delegationAddress, uint256 _date, uint8 _useCase) public view returns (bool) {
         address[] memory allActiveDelegators = retrieveActiveDelegators(_delegationAddress, _collectionAddress, _date, _useCase);
-        bool status;
-        if (allActiveDelegators.length > 0) {
-            for (uint256 i = 0; i < allActiveDelegators.length; ) {
-                if (_delegatorAddress == allActiveDelegators[i]) {
-                    status = true;
-                    break;
-                } else {
-                    status = false;
-                }
 
-                unchecked {
-                    ++i;
-                }
+        for (uint256 i = 0; i < allActiveDelegators.length; ) {
+            if (_delegatorAddress == allActiveDelegators[i]) {
+                return true;
             }
-            return status;
-        } else {
-            return false;
+
+            unchecked {
+                ++i;
+            }
         }
+
+        return false;
     }
 
     // Retrieve Delegations delegated by a Delegator

--- a/src/DelegationManagement.sol
+++ b/src/DelegationManagement.sol
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: MIT
 
-//     _   ______________                                       
-//    / | / / ____/_  __/                                       
-//   /  |/ / /_    / /                                          
-//  / /|  / __/   / /                                           
+//     _   ______________
+//    / | / / ____/_  __/
+//   /  |/ / /_    / /
+//  / /|  / __/   / /
 // /_/ |_/_/ ____/_/_    _______________  ______________  _   __
 //    / __ \/ ____/ /   / ____/ ____/   |/_  __/  _/ __ \/ | / /
-//   / / / / __/ / /   / __/ / / __/ /| | / /  / // / / /  |/ / 
-//  / /_/ / /___/ /___/ /___/ /_/ / ___ |/ / _/ // /_/ / /|  /  
-// /_____/_____/_____/_____/\____/_/  |_/_/ /___/\____/_/ |_/   
-                                                             
+//   / / / / __/ / /   / __/ / / __/ /| | / /  / // / / /  |/ /
+//  / /_/ / /___/ /___/ /___/ /_/ / ___ |/ / _/ // /_/ / /|  /
+// /_____/_____/_____/_____/\____/_/  |_/_/ /___/\____/_/ |_/
 
 /**
  *
@@ -177,7 +176,7 @@ contract DelegationManagementContract {
         _tokenId = _allTokens ? 0 : _tokenId;
         GlobalData memory newdelegationGlobalData = GlobalData(msg.sender, _delegationAddress, block.timestamp, _expiryDate, _allTokens, _tokenId);
         globalDelegationHashes[globalHash].push(newdelegationGlobalData);
-        
+
         emit RegisterDelegationUsingSubDelegation(_delegatorAddress, msg.sender, _collectionAddress, _delegationAddress, _useCase, _allTokens, _tokenId);
     }
 
@@ -231,7 +230,7 @@ contract DelegationManagementContract {
                     unchecked {
                         ++j;
                     }
-                }                
+                }
             }
             // Revoke delegator Address from the delegationAddressHashes mapping
             uint256 countDA = 0;
@@ -295,7 +294,7 @@ contract DelegationManagementContract {
                     unchecked {
                         ++i;
                     }
-                }     
+                }
             }
             // Check subdelegation rights for All collections
             allDelegators = retrieveDelegators(msg.sender, ALL_COLLECTIONS, USE_CASE_SUB_DELEGATION);
@@ -612,7 +611,7 @@ contract DelegationManagementContract {
             if ((globalDelegationHashes[hash][i].allTokens == false) && (globalDelegationHashes[hash][i].tokens == _tokenId)) {
                 return true;
             }
-            
+
             unchecked {
                 ++i;
             }
@@ -647,6 +646,7 @@ contract DelegationManagementContract {
 
         return false;
     }
+
     /**
      * @notice Checks the status of an active delegator for a delegation Address
      */


### PR DESCRIPTION
Two meaningful refactors here:

## [Clean up _allToken checks...](https://github.com/6529-Collections/nftdelegation/commit/fa8b5fa960c7eaec6783edbc22ed0e3b851ce128) 

Since this code is checking true / false and then inserting bool literal true / false respecitvely, we can just use the variable.

the only other differnce between the 2 branches of the conditiional is to ensure _tokenId is 0 when _allTokens is true. We can handle that with a conditional assignment of 0, or keeping the existing value on _tokenId.


## [Refactor unneeded if statements prior to loops...](https://github.com/6529-Collections/nftdelegation/commit/5b8ad3e73f74113a26b59cdb3993dfe5c67c070b) 

When we are looping over the something based on the length (how many hashes), we don't need to check if it's greater than 0... If it is 0, the for loop won't execute at all anyway.

This also simplified the logic and readability of the return pattern: just return from in the loop if true, and otherwise return false.

Eliminating the status variable reduces storage and complexit, and improves readability.
