### PR TITLE
Makes formatter settings align with current codebase...

### DIFF
--- a/src/.prettierrc.json
+++ b/src/.prettierrc.json
@@ -3,7 +3,7 @@
       {
         "files": "*.sol",
         "options": {
-          "printWidth": 140,
+          "printWidth": 240,
           "tabWidth": 4,
           "useTabs": false,
           "singleQuote": false,


### PR DESCRIPTION
Currently the code has a lot of long lines in function definitions. 

If we want to keep those as long single lines, the formatter settings should allow it.